### PR TITLE
Fix typo in Cargo.toml keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/terror/just-lsp"
 repository = "https://github.com/terror/just-lsp"
 edition = "2021"
 categories = ["development-tools"]
-keywords = ["productivity", "compilers", "languager-servers", "just", "tree-sitter"]
+keywords = ["productivity", "compilers", "language-servers", "just", "tree-sitter"]
 resolver = "2"
 
 include = [


### PR DESCRIPTION
Noticed a typo in `Cargo.toml`