### PR TITLE
Update `"default"` attribute with the release version

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -18,7 +18,7 @@ pub(crate) const BUILTINS: [Builtin<'_>; 134] = [
   Builtin::Attribute {
     name: "default",
     description: "Use recipe as module's default recipe.",
-    version: "master",
+    version: "1.43.0",
     targets: &[AttributeTarget::Recipe],
     parameters: None,
   },


### PR DESCRIPTION
[1.43.0](https://github.com/casey/just/blob/master/CHANGELOG.md#1430---2025-09-27)