### PR TITLE
Fix `metadata` attribute arity to allow multiple arguments

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -633,6 +633,18 @@ mod tests {
   }
 
   #[test]
+  fn attributes_metadata_multiple_arguments() {
+    Test::new(indoc! {
+      "
+      [metadata('foo', 'bar')]
+      foo:
+        echo \"foo\"
+      "
+    })
+    .run();
+  }
+
+  #[test]
   fn attributes_on_assignments() {
     Test::new(indoc! {
       "

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -134,7 +134,7 @@ pub(crate) const BUILTINS: [Builtin<'_>; 148] = [
     targets: &[AttributeTarget::Recipe],
     syntax: Some("METADATA"),
     min_args: 1,
-    max_args: Some(1),
+    max_args: None,
   },
   Builtin::Attribute {
     name: "linux",


### PR DESCRIPTION
Resolves https://github.com/terror/just-lsp/issues/241