### PR TITLE
Allow multiple arguments in `[script(...)]`

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -237,7 +237,7 @@ pub(crate) const BUILTINS: [Builtin<'_>; 148] = [
     targets: &[AttributeTarget::Recipe],
     syntax: Some("COMMAND"),
     min_args: 1,
-    max_args: Some(1),
+    max_args: None,
   },
   Builtin::Attribute {
     name: "unix",


### PR DESCRIPTION
Just accepts this syntax, even though it's missing in the documentation.
