### PR TITLE
Fix formatting for justfiles with relative imports

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use {
   },
   str_ext::StrExt,
   subcommand::Subcommand,
-  tempfile::tempdir,
+  tempfile::Builder,
   text_node::TextNode,
   tokio::{io::AsyncBufReadExt, sync::RwLock},
   tokio_stream::{StreamExt, wrappers::LinesStream},


### PR DESCRIPTION
Resolves https://github.com/terror/just-lsp/issues/76, https://github.com/terror/just-lsp/issues/81

Previously, formatting wrote the document content to a file in a temporary directory and ran `just --fmt` there. This broke justfiles with relative imports like import `"../justfile"`, since the imported paths can't resolve from the temporary directory. Now the temp file is created in the same directory as the original justfile using `--justfile` to point `just --fmt` at it, so relative imports resolve correctly. The in-memory document content is still written to the temp file, avoiding the issue where reading from the original path on disk would discard unsaved edits.