### PR TITLE
Document `zed` development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,23 +190,6 @@ https://github.com/jackTabsCode/zed-just, written by
 that repository to get it setup on your system.
 
 
-If you want to develop on zed against your local `just-lsp`, add something like this to
-your `settings.json`.
-```settings.json
- "lsp": {
-    "just-lsp": {
-      "binary": {
-        "path": "~/just-lsp/target/debug/just-lsp",
-      },
-    },
-  },
-  "languages": {
-    "Just": {
-      "language_servers": ["just-lsp"],
-    },
-  },
-```
-
 
 Add a new key binding to restart lsp to `keymap.json`
 
@@ -324,6 +307,29 @@ end
 As in the basic example above, we use `cmp_nvim_lsp.default_capabilities()` so
 that the dev build inherits completion-related capabilities from `nvim-cmp`.
 Swap in your own table if you use a different completion plugin.
+
+
+
+### Zed
+
+
+
+If you want to develop on zed against your local `just-lsp`, add something like this to
+your `settings.json`.
+```settings.json
+ "lsp": {
+    "just-lsp": {
+      "binary": {
+        "path": "~/just-lsp/target/debug/just-lsp",
+      },
+    },
+  },
+  "languages": {
+    "Just": {
+      "language_servers": ["just-lsp"],
+    },
+  },
+```
 
 **n.b.** This setup requires the
 [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) plugin (and

--- a/README.md
+++ b/README.md
@@ -189,6 +189,36 @@ https://github.com/jackTabsCode/zed-just, written by
 [@mattrobenolt](https://github.com/mattrobenolt). Follow the instructions in
 that repository to get it setup on your system.
 
+
+If you want to develop on zed against your local `just-lsp`, add something like this to
+your `settings.json`.
+```settings.json
+ "lsp": {
+    "just-lsp": {
+      "binary": {
+        "path": "~/just-lsp/target/debug/just-lsp",
+      },
+    },
+  },
+  "languages": {
+    "Just": {
+      "language_servers": ["just-lsp"],
+    },
+  },
+```
+
+
+Add a new key binding to restart lsp to `keymap.json`
+
+
+
+```
+    "context": "Editor",
+    "bindings": {
+      "ctrl-r l": "editor::RestartLanguageServer"
+    }
+```
+
 ## Configuration
 
 `just-lsp` accepts configuration through the LSP `initializationOptions` object,

--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ Add a new key binding to restart lsp to `keymap.json`
     }
 ```
 
+
+or use `editor: restart language server` in the command palette.
+
 ## Configuration
 
 `just-lsp` accepts configuration through the LSP `initializationOptions` object,

--- a/README.md
+++ b/README.md
@@ -292,11 +292,6 @@ vim.lsp.enable('just')
 
 ## Development
 
-I use [Neovim](https://neovim.io/) to work on this project, and I load the
-development build of this server to test out my changes instantly. This section
-describes a development setup using Neovim as the LSP client, for other clients
-you would need to look up their respective documentation.
-
 First, clone the repository and build the project:
 
 ```
@@ -305,7 +300,10 @@ cd just-lsp
 cargo build
 ```
 
-Add this to your editor configuration:
+### Neovim
+
+To use the development build as Neovim's language server, add this to your
+editor configuration:
 
 ```lua
 local dev_cmd = '/path/to/just-lsp/target/debug/just-lsp'
@@ -355,6 +353,39 @@ Swap in your own table if you use a different completion plugin.
 [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) plugin (and
 optionally [cmp-nvim-lsp](https://github.com/hrsh7th/cmp-nvim-lsp) for the
 capabilities helper).
+
+### Zed
+
+After installing the
+[Zed Justfile extension](https://github.com/jackTabsCode/zed-just), point its
+`just-lsp` adapter at the development binary in your Zed `settings.json`:
+
+```json
+{
+  "lsp": {
+    "just-lsp": {
+      "binary": {
+        "path": "/absolute/path/to/just-lsp/target/debug/just-lsp"
+      }
+    }
+  }
+}
+```
+
+The binary path must be absolute. After rebuilding the server, run
+`editor: restart language server` from the command palette. You can optionally
+add a shortcut for this action to `keymap.json`:
+
+```json
+[
+  {
+    "context": "Editor",
+    "bindings": {
+      "ctrl-r l": "editor::RestartLanguageServer"
+    }
+  }
+]
+```
 
 ### Extending the parser
 


### PR DESCRIPTION
Documents how to run a locally built `just-lsp` binary through the Zed Justfile extension and restart the language server after rebuilding.

The examples use the extension’s registered `just-lsp` adapter, an absolute binary path as required by Zed, and valid `settings.json` and `keymap.json` structures.