### PR TITLE
Clamp out-of-bounds LSP column to rope length

### DIFF
--- a/src/rope_ext.rs
+++ b/src/rope_ext.rs
@@ -131,9 +131,17 @@ impl RopeExt for Rope {
     let row_char = self.line_to_char(row);
     let row_byte = self.line_to_byte(row);
 
-    let col_char = self.utf16_cu_to_char(
-      self.char_to_utf16_cu(row_char) + position.character as usize,
-    );
+    // Clamp the target UTF-16 code unit to the rope's total so a
+    // position beyond end-of-document (observed when an editor sends a
+    // didChange with a range that extends past the current buffer, see
+    // ropey#728) becomes "end of rope" rather than a panic inside
+    // ropey::utf16_cu_to_char (#343).
+    let target_utf16_cu = self
+      .char_to_utf16_cu(row_char)
+      .saturating_add(position.character as usize)
+      .min(self.len_utf16_cu());
+
+    let col_char = self.utf16_cu_to_char(target_utf16_cu);
 
     let col_byte = self.char_to_byte(col_char);
 
@@ -307,6 +315,24 @@ mod tests {
       Position {
         byte: 5,
         char: 2,
+        point: Point::new(0, 5),
+      }
+    );
+  }
+
+  #[test]
+  fn lsp_position_past_end_clamps_instead_of_panicking() {
+    // #343: an LSP client sending a position whose column exceeds the
+    // actual UTF-16 length of the buffer must not take down the server.
+    let rope = Rope::from_str("hello");
+
+    let end = rope.lsp_position_to_position(lsp::Position::new(0, 5000));
+
+    assert_eq!(
+      end,
+      Position {
+        byte: 5,
+        char: 5,
         point: Point::new(0, 5),
       }
     );


### PR DESCRIPTION
## Summary

Fixes #343.

`RopeExt::lsp_position_to_position` feeds `position.character` straight into `ropey::utf16_cu_to_char`. When the requested UTF-16 code unit exceeds the rope's total length, ropey unwraps a `Utf16 code-unit index out of bounds` error and the language server panics:

```
thread 'main' panicked at .../ropey-1.6.1/src/rope.rs:728:49:
called `Result::unwrap()` on an `Err` value: Utf16 code-unit index out of bounds:
  utf16 index 789, Rope/RopeSlice utf16 length 778
```

Editors occasionally send such a column (a range that extends past end-of-document during a `didChange`, a hover position computed from a stale buffer, etc.), and taking the whole server down instead of treating the target as end-of-document is obviously worse than clamping.

## Fix

Cap the target UTF-16 code unit at `self.len_utf16_cu()`, and use `saturating_add` so the arithmetic itself can't wrap on attacker-controlled `character` values. Added a `lsp_position_past_end_clamps_instead_of_panicking` regression test that asserts a column of 5000 on a 5-character buffer returns the end position without panicking.

## Test plan

- [x] `cargo build`
- [x] `cargo test --lib rope_ext` (10/10 pass, new test included)
- [x] `cargo clippy --lib --all-targets` (no new warnings)
