### PR TITLE
Fix unused parameter warning for positional shebang recipes

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1942,12 +1942,12 @@ mod tests {
   #[test]
   fn positional_arguments_shebang_marks_all_as_used() {
     Test::new(indoc! {
-      r#"
+      r"
       [positional-arguments]
       run *args:
         #!/usr/bin/env -S deno run
         console.log(Deno.args)
-      "#
+      "
     })
     .run();
   }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1940,6 +1940,19 @@ mod tests {
   }
 
   #[test]
+  fn positional_arguments_shebang_marks_all_as_used() {
+    Test::new(indoc! {
+      r#"
+      [positional-arguments]
+      run *args:
+        #!/usr/bin/env -S deno run
+        console.log(Deno.args)
+      "#
+    })
+    .run();
+  }
+
+  #[test]
   fn positional_arguments_disabled_still_warns() {
     Test::new(indoc! {
       "

--- a/src/rule/unused_parameters.rs
+++ b/src/rule/unused_parameters.rs
@@ -25,7 +25,8 @@ define_rule! {
           let (positional_usage, uses_all) = if recipe_enables_positional_arguments {
             (
               UnusedParameterRule::positional_argument_indices(recipe),
-              UnusedParameterRule::uses_all_positional_arguments(recipe),
+              recipe.shebang.is_some()
+                || UnusedParameterRule::uses_all_positional_arguments(recipe),
             )
           } else {
             (HashSet::new(), false)


### PR DESCRIPTION
Resolves https://github.com/terror/just-lsp/issues/378

This diff fixes a false `unused-parameters` warning for shebang recipes that use `[positional-arguments]`. In that mode, recipe parameters are passed to the script as positional arguments, so they may be consumed by the interpreter or runtime through APIs like `Deno.args` rather than appearing directly in the justfile body as `$1` or `$@`.

The `unused-parameters` rule now treats all parameters in positional-arguments shebang recipes as used, while preserving the existing stricter scan for non-shebang recipes. 
