### PR TITLE
Allow optional `split` function separator

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1772,34 +1772,40 @@ mod tests {
 
   #[test]
   fn function_calls_split() {
-    Test::new(indoc! {
-      "
-      set lists
+    #[track_caller]
+    fn case(expression: &str) {
+      Test::new(&formatdoc! {
+        "
+        set lists
 
-      foo := split(\"foo,bar\", \",\")
+        foo := {expression}
 
-      bar:
-        echo {{ foo }}
-      "
-    })
-    .run();
+        bar:
+          echo {{{{ foo }}}}
+        "
+      })
+      .run();
+    }
+
+    case("split(\"foo bar\")");
+    case("split(\"foo,bar\", \",\")");
   }
 
   #[test]
-  fn function_calls_split_too_few_args() {
+  fn function_calls_split_rejects_missing_argument() {
     Test::new(indoc! {
       "
       set lists
 
-      foo := split(\"foo,bar\")
+      foo := split()
 
       bar:
         echo {{ foo }}
       "
     })
     .error(
-      "Function `split` requires at least 2 arguments, but 1 provided",
-      lsp::Range::at(2, 7, 2, 23),
+      "Function `split` requires at least 1 argument, but 0 provided",
+      lsp::Range::at(2, 7, 2, 14),
     )
     .run();
   }
@@ -1817,7 +1823,7 @@ mod tests {
       "
     })
     .error(
-      "Function `split` accepts 2 arguments, but 3 provided",
+      "Function `split` accepts at most 2 arguments, but 3 provided",
       lsp::Range::at(2, 7, 2, 35),
     )
     .run();

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -196,7 +196,7 @@ impl Builtin<'_> {
         format!("{name}(${{1:command:string}}${{2:, args:string...}})")
       }
       "split" => {
-        format!("{name}(${{1:string:string}}, ${{2:separator:string}})")
+        format!("{name}(${{1:string:string}}${{2:, separator:string}})")
       }
       "trim_end_match" | "trim_end_matches" | "trim_start_match"
       | "trim_start_matches" => {

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1940,10 +1940,12 @@ pub const BUILTINS: &[Builtin<'_>] = &[
   Builtin::Function {
     name: "split",
     aliases: &[],
-    kind: FunctionKind::Binary,
+    kind: FunctionKind::UnaryOpt,
     description: indoc! {
       "
-      Split `string` on `separator`, returning a list.
+      Split `string` on `separator`, or whitespace if `separator` is
+      not provided, returning a list.
+
       Requires `set lists`.
       "
     },


### PR DESCRIPTION
Allow `split` to be called with only the string argument, matching upstream `just` whitespace-splitting behavior when the separator is omitted.

Upstream documentation: https://github.com/casey/just#functions
