### PR TITLE
Fix attribute duplicate diagnostics

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -426,6 +426,23 @@ mod tests {
   }
 
   #[test]
+  fn arg_attribute_duplicate_parameter() {
+    Test::new(indoc! {
+      "
+      [arg('foo', help='bar')]
+      [arg('foo', long='foo')]
+      bar foo:
+        echo {{foo}}
+      "
+    })
+    .error(
+      "`[arg]` attribute for parameter `foo` is duplicated",
+      lsp::Range::at(1, 0, 2, 0),
+    )
+    .run();
+  }
+
+  #[test]
   fn arg_attribute_with_flag() {
     Test::new(indoc! {
       "
@@ -682,7 +699,7 @@ mod tests {
   }
 
   #[test]
-  fn attributes_duplicate_group_attribute() {
+  fn attributes_duplicate_group_attribute_allowed() {
     Test::new(indoc! {
       "
       [group('dev')]
@@ -691,10 +708,6 @@ mod tests {
         echo \"build\"
       "
     })
-    .error(
-      "Recipe attribute `group` is duplicated",
-      lsp::Range::at(1, 0, 2, 0),
-    )
     .run();
   }
 
@@ -713,6 +726,54 @@ mod tests {
       lsp::Range::at(1, 0, 2, 0),
     )
     .run();
+  }
+
+  #[test]
+  fn attributes_duplicate_non_repeatable_outside_recipes() {
+    #[track_caller]
+    fn case(content: &'static str, message: &'static str) {
+      Test::new(content)
+        .error(message, lsp::Range::at(1, 0, 2, 0))
+        .run();
+    }
+
+    case(
+      indoc! {
+        "
+        [private]
+        [private]
+        alias f := foo
+
+        foo:
+        "
+      },
+      "Alias attribute `private` is duplicated",
+    );
+
+    case(
+      indoc! {
+        "
+        [private]
+        [private]
+        foo := 'bar'
+
+        bar:
+          echo {{foo}}
+        "
+      },
+      "Assignment attribute `private` is duplicated",
+    );
+
+    case(
+      indoc! {
+        "
+        [doc('foo')]
+        [doc('bar')]
+        mod foo
+        "
+      },
+      "Module attribute `doc` is duplicated",
+    );
   }
 
   #[test]
@@ -1505,7 +1566,7 @@ mod tests {
   }
 
   #[test]
-  fn env_attribute_duplicate_var_name() {
+  fn env_attribute_duplicate_var_name_allowed() {
     Test::new(indoc! {
       "
       [env('FOO', 'bar')]
@@ -1514,10 +1575,6 @@ mod tests {
         echo \"$FOO\"
       "
     })
-    .error(
-      "Recipe attribute `env` is duplicated",
-      lsp::Range::at(1, 0, 2, 0),
-    )
     .run();
   }
 

--- a/src/attribute_target.rs
+++ b/src/attribute_target.rs
@@ -25,6 +25,16 @@ impl Display for AttributeTarget {
 
 impl AttributeTarget {
   #[must_use]
+  pub fn target_name(self) -> &'static str {
+    match self {
+      Self::Alias => "Alias",
+      Self::Assignment => "Assignment",
+      Self::Module => "Module",
+      Self::Recipe => "Recipe",
+    }
+  }
+
+  #[must_use]
   pub fn try_from_kind(kind: &str) -> Option<Self> {
     match kind {
       "alias" => Some(Self::Alias),

--- a/src/rule/arg_attribute.rs
+++ b/src/rule/arg_attribute.rs
@@ -15,19 +15,55 @@ define_rule! {
         return Vec::new();
       };
 
-      tree
-        .root_node()
-        .find_all("attribute")
-        .into_iter()
-        .flat_map(|attribute| {
-          attribute
-            .find_all("^identifier")
-            .into_iter()
-            .filter(|node| context.document().get_node_text(node) == "arg")
-            .flat_map(move |identifier| Self::validate(context, attribute, identifier))
-            .collect::<Vec<_>>()
-        })
-        .collect()
+      let document = context.document();
+
+      let mut diagnostics = Vec::new();
+      let mut seen = HashSet::new();
+
+      for attribute in tree.root_node().find_all("attribute") {
+        for identifier in attribute.find_all("^identifier") {
+          if document.get_node_text(&identifier) != "arg" {
+            continue;
+          }
+
+          diagnostics.extend(Self::validate(context, attribute, identifier));
+
+          let Some(recipe_node) = attribute.get_parent("recipe") else {
+            continue;
+          };
+
+          let Some(name_node) = identifier
+            .siblings()
+            .take_while(|node| node.kind() != "identifier")
+            .find(|node| {
+              node.kind() == "expression"
+                && node.start_byte() != node.end_byte()
+            })
+          else {
+            continue;
+          };
+
+          let parameter_name = document
+            .get_node_text(&name_node)
+            .trim_matches(|c| c == '\'' || c == '"')
+            .to_string();
+
+          if !seen.insert((
+            recipe_node.start_byte(),
+            recipe_node.end_byte(),
+            parameter_name.clone(),
+          )) {
+            diagnostics.push(Diagnostic::error(
+              format!(
+                "`[arg]` attribute for parameter `{parameter_name}` is duplicated"
+              ),
+              attribute.get_range(document),
+            ));
+          }
+        }
+      }
+
+      diagnostics
     }
   }
 }

--- a/src/rule/duplicate_attribute.rs
+++ b/src/rule/duplicate_attribute.rs
@@ -1,227 +1,79 @@
 use super::*;
 
-#[derive(Clone, Copy, Debug)]
-enum DuplicateScope {
-  /// Attribute must be unique within the entire document.
-  Module,
-  /// Attribute must be unique per recipe.
-  Recipe,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum DuplicateKey {
-  Argument,
-  Name,
-}
-
-#[derive(Debug)]
-struct DuplicateConstraint {
-  key: DuplicateKey,
-  name: &'static str,
-  scope: DuplicateScope,
-}
-
-const DUPLICATE_CONSTRAINTS: &[DuplicateConstraint] = &[
-  DuplicateConstraint {
-    name: "default",
-    scope: DuplicateScope::Module,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "confirm",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "doc",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "exit-message",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "env",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Argument,
-  },
-  DuplicateConstraint {
-    name: "extension",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "group",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Argument,
-  },
-  DuplicateConstraint {
-    name: "dragonfly",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "freebsd",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "linux",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "macos",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "no-cd",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "no-exit-message",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "no-quiet",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "netbsd",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "openbsd",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "parallel",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "positional-arguments",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "private",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "script",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "shell",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "unix",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "windows",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-  DuplicateConstraint {
-    name: "working-directory",
-    scope: DuplicateScope::Recipe,
-    key: DuplicateKey::Name,
-  },
-];
+const REPEATABLE_ATTRIBUTES: &[&str] = &["arg", "env", "group", "metadata"];
 
 define_rule! {
-  /// Reports duplicate usages of attributes that must be unique.
   DuplicateAttributeRule {
     id: "duplicate-attribute",
     message: "duplicate attribute",
     run(context) {
-      let mut diagnostics = Vec::new();
+      let Some(tree) = context.tree() else {
+        return Vec::new();
+      };
 
-      let mut module_seen: HashMap<&'static str, HashSet<String>> =
+      let document = context.document();
+
+      let mut diagnostics = Vec::new();
+      let mut default_recipe = None;
+
+      let mut target_seen: HashMap<(usize, usize), HashSet<String>> =
         HashMap::new();
 
-      for recipe in context.recipes() {
-        let mut recipe_seen: HashMap<&'static str, HashSet<String>> =
-          HashMap::new();
+      for attribute_node in tree.root_node().find_all("attribute") {
+        let Some(parent) = attribute_node.parent() else {
+          continue;
+        };
 
-        for attribute in &recipe.attributes {
-          let attribute_name = attribute.name.value.as_str();
+        let Some(target) = AttributeTarget::try_from_kind(parent.kind()) else {
+          continue;
+        };
 
-          let Some(constraint) = DuplicateAttributeRule::constraint(attribute_name) else {
+        let target_key = (parent.start_byte(), parent.end_byte());
+
+        for identifier in attribute_node.find_all("^identifier") {
+          let attribute_name = document.get_node_text(&identifier);
+
+          if context.builtin_attributes(&attribute_name).is_empty()
+            || REPEATABLE_ATTRIBUTES.contains(&attribute_name.as_str())
+          {
             continue;
-          };
+          }
 
-          let Some(key) = DuplicateAttributeRule::key(constraint, attribute) else {
+          if attribute_name == "default" && target == AttributeTarget::Recipe {
+            let Some(recipe_name) = parent
+              .find("recipe_header > identifier")
+              .map(|node| document.get_node_text(&node))
+            else {
+              continue;
+            };
+
+            if default_recipe.replace(recipe_name.clone()).is_some() {
+              diagnostics.push(Diagnostic::error(
+                format!(
+                  "Recipe `{recipe_name}` has duplicate `[default]` attribute, which may only appear once per module"
+                ),
+                attribute_node.get_range(document),
+              ));
+            }
+
             continue;
-          };
+          }
 
-          let seen = match constraint.scope {
-            DuplicateScope::Module => {
-              module_seen.entry(constraint.name).or_default()
-            }
-            DuplicateScope::Recipe => {
-              recipe_seen.entry(constraint.name).or_default()
-            }
-          };
+          let seen = target_seen.entry(target_key).or_default();
 
-          if !seen.insert(key.clone()) {
+          if !seen.insert(attribute_name.clone()) {
             diagnostics.push(Diagnostic::error(
-              DuplicateAttributeRule::message(constraint, recipe),
-              attribute.range,
+              format!(
+                "{} attribute `{attribute_name}` is duplicated",
+                target.target_name()
+              ),
+              attribute_node.get_range(document),
             ));
           }
         }
       }
 
       diagnostics
-    }
-  }
-}
-
-impl DuplicateAttributeRule {
-  fn constraint(name: &str) -> Option<&'static DuplicateConstraint> {
-    DUPLICATE_CONSTRAINTS
-      .iter()
-      .find(|constraint| constraint.name == name)
-  }
-
-  fn key(
-    constraint: &DuplicateConstraint,
-    attribute: &Attribute,
-  ) -> Option<String> {
-    match constraint.key {
-      DuplicateKey::Name => Some(attribute.name.value.clone()),
-      DuplicateKey::Argument => attribute
-        .arguments
-        .first()
-        .map(|argument| argument.value.clone()),
-    }
-  }
-
-  fn message(constraint: &DuplicateConstraint, recipe: &Recipe) -> String {
-    match constraint.scope {
-      DuplicateScope::Module => format!(
-        "Recipe `{}` has duplicate `[{}]` attribute, which may only appear once per module",
-        recipe.name.value, constraint.name
-      ),
-      DuplicateScope::Recipe => {
-        format!("Recipe attribute `{}` is duplicated", constraint.name)
-      }
     }
   }
 }


### PR DESCRIPTION
Align duplicate attribute diagnostics with upstream `just` attribute repeatability. Repeated `[env]` and `[group]` attributes are allowed, duplicate `[arg]` annotations for the same parameter are rejected, and non-repeatable attributes on non-recipe targets are checked.

Upstream documentation: https://github.com/casey/just#attributes
