### PR TITLE
Add rule for list feature gating

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -34,6 +34,7 @@ the rule’s identifier in the `code` field so editors can group or filter them.
 | `function-arguments`              | Function Arguments              | Builtin function call uses the wrong number of arguments.                                                                     |
 | `duplicate-function`              | Duplicate Function              | User-defined function name is defined more than once.                                                                         |
 | `function-parameters`             | Function Parameters             | User-defined function parameter list has duplicates.                                                                          |
+| `list-features`                   | List Features                   | Syntax and builtins that require `set lists` are used without enabling it.                                                    |
 | `unknown-setting`                 | Unknown Setting                 | `set` statement references an unknown setting.                                                                                |
 | `invalid-setting-kind`            | Invalid Setting Kind            | Setting is assigned a value of the wrong type (bool/string/array).                                                            |
 | `duplicate-setting`               | Duplicate Setting               | Setting key is configured more than once.                                                                                     |

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -171,9 +171,11 @@ mod tests {
   }
 
   #[test]
-  fn accepts_logical_operators() {
+  fn accepts_logical_operators_with_lists() {
     Test::new(indoc! {
       "
+      set lists
+
       foo := '' || 'bar'
       bar := 'foo' && 'bar'
 
@@ -186,9 +188,11 @@ mod tests {
   }
 
   #[test]
-  fn accepts_unary_negation() {
+  fn accepts_unary_negation_with_lists() {
     Test::new(indoc! {
       "
+      set lists
+
       foo bar:
         echo {{ !bar }}
       "
@@ -446,11 +450,29 @@ mod tests {
   fn arg_attribute_with_flag() {
     Test::new(indoc! {
       "
+      set lists
+
       [arg('foo', flag)]
       bar foo:
         echo {{foo}}
       "
     })
+    .run();
+  }
+
+  #[test]
+  fn arg_attribute_with_flag_requires_lists() {
+    Test::new(indoc! {
+      "
+      [arg('foo', flag)]
+      bar foo:
+        echo {{foo}}
+      "
+    })
+    .error(
+      "`flag` arguments require `set lists`",
+      lsp::Range::at(0, 12, 0, 16),
+    )
     .run();
   }
 
@@ -2034,6 +2056,267 @@ mod tests {
   }
 
   #[test]
+  fn list_features_allow_shadowed_functions_without_lists() {
+    Test::new(indoc! {
+      "
+      bool(value) := value
+      join_list(value) := value
+      show(value) := value
+      split(value) := value
+      which(value) := value
+
+      foo := bool('foo')
+      bar := join_list('bar')
+      baz := show('baz')
+      qux := split('qux')
+      quux := which('quux')
+
+      recipe:
+        echo {{ foo }}
+        echo {{ bar }}
+        echo {{ baz }}
+        echo {{ qux }}
+        echo {{ quux }}
+      "
+    })
+    .run();
+  }
+
+  #[test]
+  fn list_features_bool_function_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := bool('true')
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "the `bool()` function requires `set lists`",
+      lsp::Range::at(0, 7, 0, 11),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_comparison_as_value_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := 'a' == 'b'
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "comparison operators require `set lists`",
+      lsp::Range::at(0, 11, 0, 13),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_if_without_else_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := if 'a' == 'b' { 'c' }
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "`if` without `else` requires `set lists`",
+      lsp::Range::at(0, 7, 0, 9),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_join_list_function_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := join_list('bar')
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "the `join_list()` function requires `set lists`",
+      lsp::Range::at(0, 7, 0, 16),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_list_concatenation_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := 'a' ++ 'b'
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "list concatenation operator `++` requires `set lists`",
+      lsp::Range::at(0, 11, 0, 13),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_list_literals_require_lists() {
+    Test::new(indoc! {
+      "
+      foo := ['bar']
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "list literals require `set lists`",
+      lsp::Range::at(0, 7, 0, 14),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_logical_and_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := 'foo' && 'bar'
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "logical operators require `set lists`",
+      lsp::Range::at(0, 13, 0, 15),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_logical_or_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := '' || 'bar'
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "logical operators require `set lists`",
+      lsp::Range::at(0, 10, 0, 12),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_negation_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo bar:
+        echo {{ !bar }}
+      "
+    })
+    .error(
+      "negation operator requires `set lists`",
+      lsp::Range::at(1, 10, 1, 11),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_non_comparison_assert_condition_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo:
+        echo {{ assert('bar') }}
+      "
+    })
+    .error(
+      "`if` and `assert` conditions other than comparisons require `set lists`",
+      lsp::Range::at(1, 17, 1, 22),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_non_comparison_if_condition_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := if 'a' { 'b' } else { 'c' }
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "`if` and `assert` conditions other than comparisons require `set lists`",
+      lsp::Range::at(0, 10, 0, 13),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_show_function_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := show('bar')
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "the `show()` function requires `set lists`",
+      lsp::Range::at(0, 7, 0, 11),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_split_function_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := split('bar')
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "the `split()` function requires `set lists`",
+      lsp::Range::at(0, 7, 0, 12),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_which_function_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := which('bar')
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "the `which()` function requires `set lists`",
+      lsp::Range::at(0, 7, 0, 12),
+    )
+    .run();
+  }
+
+  #[test]
   fn linux_openbsd_no_conflict() {
     Test::new(indoc! {
       "
@@ -3359,7 +3642,7 @@ mod tests {
   #[test]
   fn settings_dotenv_lists_require_lists() {
     #[track_caller]
-    fn case(setting: &str, message: &'static str) {
+    fn case(setting: &str, range: lsp::Range) {
       Test::new(&formatdoc! {
         r#"
         set {setting} := ["foo", "bar"]
@@ -3368,19 +3651,12 @@ mod tests {
           echo "foo"
         "#
       })
-      .error(message, lsp::Range::at(0, 0, 1, 0))
+      .error("list literals require `set lists`", range)
       .run();
     }
 
-    case(
-      "dotenv-filename",
-      "Setting `dotenv-filename` expects a string value",
-    );
-
-    case(
-      "dotenv-path",
-      "Setting `dotenv-path` expects a string value",
-    );
+    case("dotenv-filename", lsp::Range::at(0, 23, 0, 37));
+    case("dotenv-path", lsp::Range::at(0, 19, 0, 33));
   }
 
   #[test]

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -58,6 +58,7 @@ mod function_parameters;
 mod inconsistent_indentation;
 mod invalid_import_path;
 mod invalid_setting_kind;
+mod list_features;
 mod mapped_dependencies;
 mod missing_dependencies;
 mod missing_recipe_for_alias;

--- a/src/rule/invalid_setting_kind.rs
+++ b/src/rule/invalid_setting_kind.rs
@@ -16,13 +16,12 @@ define_rule! {
           continue;
         };
 
-        let list_dotenv_setting = matches!(
+        let dotenv_array_setting = matches!(
           setting.name.value.as_str(),
           "dotenv-filename" | "dotenv-path"
-        ) && context.setting_enabled("lists")
-          && setting.kind == SettingKind::Array;
+        ) && setting.kind == SettingKind::Array;
 
-        if setting.kind == *kind || list_dotenv_setting {
+        if setting.kind == *kind || dotenv_array_setting {
           continue;
         }
 

--- a/src/rule/list_features.rs
+++ b/src/rule/list_features.rs
@@ -1,0 +1,213 @@
+use super::*;
+
+const COMPARISON_OPERATORS: &[&str] = &["!=", "!~", "==", "=~"];
+const LOGICAL_OPERATORS: &[&str] = &["&&", "||"];
+
+define_rule! {
+  ListFeaturesRule {
+    id: "list-features",
+    message: "list feature requires set lists",
+    run(context) {
+      let mut diagnostics = Vec::new();
+
+      if context.setting_enabled("lists") {
+        return diagnostics;
+      }
+
+      let Some(tree) = context.tree() else {
+        return diagnostics;
+      };
+
+      Self::validate_node(
+        context,
+        context.document(),
+        tree.root_node(),
+        &mut diagnostics,
+      );
+
+      diagnostics
+    }
+  }
+}
+
+impl ListFeaturesRule {
+  fn arg_flag_range(document: &Document, node: Node<'_>) -> Option<lsp::Range> {
+    let name = node.child_by_field_name("name")?;
+
+    if document.get_node_text(&name) != "flag" {
+      return None;
+    }
+
+    let mut sibling = node.prev_sibling();
+
+    while let Some(node) = sibling {
+      if node.kind() == "identifier" {
+        return (document.get_node_text(&node) == "arg")
+          .then(|| name.get_range(document));
+      }
+
+      sibling = node.prev_sibling();
+    }
+
+    None
+  }
+
+  fn comparison_operator(node: Node<'_>) -> Option<Node<'_>> {
+    Self::operator(node, COMPARISON_OPERATORS)
+  }
+
+  fn condition_comparison_operator(node: Node<'_>) -> Option<Node<'_>> {
+    (0..node.child_count())
+      .filter_map(|index| node.child(index.try_into().ok()?))
+      .find(|child| child.kind() == "expression")
+      .and_then(Self::comparison_operator)
+  }
+
+  fn function_message(name: &str) -> Option<&'static str> {
+    match name {
+      "bool" => Some("the `bool()` function requires `set lists`"),
+      "join_list" => Some("the `join_list()` function requires `set lists`"),
+      "show" => Some("the `show()` function requires `set lists`"),
+      "split" => Some("the `split()` function requires `set lists`"),
+      "which" => Some("the `which()` function requires `set lists`"),
+      _ => None,
+    }
+  }
+
+  fn if_token(node: Node<'_>) -> Option<Node<'_>> {
+    (0..node.child_count())
+      .filter_map(|index| node.child(index.try_into().ok()?))
+      .find(|child| child.kind() == "if")
+  }
+
+  fn interpreter_setting_array(document: &Document, node: Node<'_>) -> bool {
+    let Some(setting) = node.get_parent("setting") else {
+      return false;
+    };
+
+    let Some(array) = setting.find("list_literal") else {
+      return false;
+    };
+
+    let Some(name) = setting.child(1) else {
+      return false;
+    };
+
+    if array.start_byte() != node.start_byte()
+      || array.end_byte() != node.end_byte()
+    {
+      return false;
+    }
+
+    matches!(
+      document.get_node_text(&name).as_str(),
+      "script-interpreter" | "shell" | "windows-shell"
+    )
+  }
+
+  fn operator<'tree>(
+    node: Node<'tree>,
+    operators: &[&str],
+  ) -> Option<Node<'tree>> {
+    (0..node.child_count())
+      .filter_map(|index| node.child(index.try_into().ok()?))
+      .find(|child| operators.contains(&child.kind()))
+  }
+
+  fn validate_node(
+    context: &RuleContext<'_>,
+    document: &Document,
+    node: Node<'_>,
+    diagnostics: &mut Vec<Diagnostic>,
+  ) {
+    match node.kind() {
+      "attribute_named_param" => {
+        if let Some(range) = Self::arg_flag_range(document, node) {
+          diagnostics.push(Diagnostic::error(
+            "`flag` arguments require `set lists`",
+            range,
+          ));
+        }
+      }
+      "condition" => {
+        if Self::condition_comparison_operator(node).is_none() {
+          diagnostics.push(Diagnostic::error(
+            "`if` and `assert` conditions other than comparisons require `set lists`",
+            node.get_range(document),
+          ));
+        }
+      }
+      "expression" => {
+        if let Some(operator) = Self::operator(node, LOGICAL_OPERATORS) {
+          diagnostics.push(Diagnostic::error(
+            "logical operators require `set lists`",
+            operator.get_range(document),
+          ));
+        }
+
+        if let Some(operator) = Self::operator(node, &["++"]) {
+          diagnostics.push(Diagnostic::error(
+            "list concatenation operator `++` requires `set lists`",
+            operator.get_range(document),
+          ));
+        }
+
+        if node
+          .parent()
+          .is_none_or(|parent| parent.kind() != "condition")
+          && let Some(operator) = Self::comparison_operator(node)
+        {
+          diagnostics.push(Diagnostic::error(
+            "comparison operators require `set lists`",
+            operator.get_range(document),
+          ));
+        }
+      }
+      "function_call" => {
+        if let Some(name) = node.child_by_field_name("name") {
+          let name_text = document.get_node_text(&name);
+
+          if !context.user_function_names().contains(&name_text)
+            && let Some(message) = Self::function_message(&name_text)
+          {
+            diagnostics
+              .push(Diagnostic::error(message, name.get_range(document)));
+          }
+        }
+      }
+      "if_expression" => {
+        if node.find("^else_clause").is_none() {
+          diagnostics.push(Diagnostic::error(
+            "`if` without `else` requires `set lists`",
+            Self::if_token(node).unwrap_or(node).get_range(document),
+          ));
+        }
+      }
+      "list_literal" => {
+        if !Self::interpreter_setting_array(document, node) {
+          diagnostics.push(Diagnostic::error(
+            "list literals require `set lists`",
+            node.get_range(document),
+          ));
+        }
+      }
+      "not_expression" => {
+        if let Some(operator) = Self::operator(node, &["!"]) {
+          diagnostics.push(Diagnostic::error(
+            "negation operator requires `set lists`",
+            operator.get_range(document),
+          ));
+        }
+      }
+      _ => {}
+    }
+
+    for index in 0..node.child_count() {
+      if let Ok(index) = index.try_into()
+        && let Some(child) = node.child(index)
+      {
+        Self::validate_node(context, document, child, diagnostics);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This diff adds a `list-features` diagnostic rule that reports upstream `set lists` gated syntax and list-only builtins when the setting is disabled. This covers list literals, list concatenation, logical operators, comparison-as-value, non-comparison conditions, `if` without `else`, negation, list-only builtins, and `[arg(..., flag)]`.

Interpreter setting arrays remain valid without `set lists`, and user-defined functions can still shadow list-only builtins.

Upstream documentation: https://github.com/casey/just#lists


