### PR TITLE
Add support for `just_version` builtin function

### DIFF
--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -141,6 +141,7 @@ impl Builtin<'_> {
       | "source_dir"
       | "just_executable"
       | "just_pid"
+      | "just_version"
       | "uuid"
       | "runtime_directory"
       | "runtime_dir"

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1472,6 +1472,22 @@ pub const BUILTINS: &[Builtin<'_>] = &[
     deprecated: None,
   },
   Builtin::Function {
+    name: "just_version",
+    aliases: &[],
+    kind: FunctionKind::Nullary,
+    description: indoc! {
+      "
+      Version of the `just` executable.
+
+      ```just
+      just-info:
+        @echo The version is: {{ just_version() }}
+      ```
+      "
+    },
+    deprecated: None,
+  },
+  Builtin::Function {
     name: "justfile",
     aliases: &[],
     kind: FunctionKind::Nullary,


### PR DESCRIPTION
Adds the `just_version()` nullary function (just 1.55.0, casey/just#3497) to the builtin catalog and completion/hover surfaces.