### PR TITLE
Mark `windows-shell` setting as deprecated

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -3748,7 +3748,7 @@ mod tests {
       lsp::Range::at(0, 0, 1, 0),
     )
     .warning(
-      "`windows-shell` is deprecated, use `[windows] attribute on `set shell`` instead",
+      "`windows-shell` is deprecated, use `[windows]` attribute on `set shell` instead",
       lsp::Range::at(0, 4, 0, 17),
     )
     .run();
@@ -3765,7 +3765,7 @@ mod tests {
       "
     })
     .warning(
-      "`windows-shell` is deprecated, use `[windows] attribute on `set shell`` instead",
+      "`windows-shell` is deprecated, use `[windows]` attribute on `set shell` instead",
       lsp::Range::at(0, 4, 0, 17),
     )
     .run();

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -3772,6 +3772,24 @@ mod tests {
   }
 
   #[test]
+  fn settings_windows_shell_replacement() {
+    Test::new(indoc! {
+      "
+      set lists
+
+      [windows]
+      set shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]
+      set windows-shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]
+      "
+    })
+    .warning(
+      "`windows-shell` is deprecated, use `[windows]` attribute on `set shell` instead",
+      lsp::Range::at(4, 4, 4, 17),
+    )
+    .run();
+  }
+
+  #[test]
   fn settings_string_type_correct() {
     Test::new(indoc! {
       "

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -3747,6 +3747,10 @@ mod tests {
       "Setting `windows-shell` expects an array value",
       lsp::Range::at(0, 0, 1, 0),
     )
+    .warning(
+      "`windows-shell` is deprecated, use `[windows] attribute on `set shell`` instead",
+      lsp::Range::at(0, 4, 0, 17),
+    )
     .run();
   }
 
@@ -3760,6 +3764,10 @@ mod tests {
         echo \"foo\"
       "
     })
+    .warning(
+      "`windows-shell` is deprecated, use `[windows] attribute on `set shell`` instead",
+      lsp::Range::at(0, 4, 0, 17),
+    )
     .run();
   }
 

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -17,13 +17,13 @@ pub enum Builtin<'a> {
     aliases: &'a [&'a str],
     kind: FunctionKind,
     description: &'a str,
-    deprecated: Option<&'a str>,
+    deprecated: Option<Deprecation<'a>>,
   },
   Setting {
     name: &'a str,
     kind: SettingKind,
     description: &'a str,
-    deprecated: Option<&'a str>,
+    deprecated: Option<Deprecation<'a>>,
   },
 }
 
@@ -250,7 +250,7 @@ mod tests {
       aliases: &[],
       kind: FunctionKind::Nullary,
       description: "",
-      deprecated: Some("bar"),
+      deprecated: Some(Deprecation::Replacement("bar")),
     }
     .completion_items()
     .into_iter()

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -631,11 +631,12 @@ pub const BUILTINS: &[Builtin<'_>] = &[
     kind: AttributeKind::Nullary,
     description: indoc! {
       "
-      Enable the recipe on Windows.
+      Enable a recipe or setting on Windows.
 
       Part of the platform-gating family of attributes. When any
       platform attribute is present, the recipe is only enabled when
-      one of the active platforms matches.
+      one of the active platforms matches. It can also specialize
+      `set shell` for Windows.
 
       ```just
       [windows]
@@ -1307,7 +1308,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       variable is unset.
       "
     },
-    deprecated: Some("env"),
+    deprecated: Some(Deprecation::Replacement("env")),
   },
   Builtin::Function {
     name: "env_var_or_default",
@@ -1321,7 +1322,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       `default` when the variable is unset.
       "
     },
-    deprecated: Some("env"),
+    deprecated: Some(Deprecation::Replacement("env")),
   },
   Builtin::Function {
     name: "error",
@@ -2762,7 +2763,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       for a more flexible, version-agnostic alternative.
       "
     },
-    deprecated: Some("windows-shell"),
+    deprecated: Some(Deprecation::Replacement("windows-shell")),
   },
   Builtin::Setting {
     name: "windows-shell",
@@ -2786,7 +2787,10 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    deprecated: Some("`[windows]` attribute on `set shell`"),
+    deprecated: Some(Deprecation::SettingAttribute {
+      attribute: "windows",
+      setting: "shell",
+    }),
   },
   Builtin::Setting {
     name: "working-directory",

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -2769,6 +2769,9 @@ pub const BUILTINS: &[Builtin<'_>] = &[
     kind: SettingKind::Array,
     description: indoc! {
       "
+      **Deprecated**: use the `[windows]` attribute on `set shell`
+      instead.
+
       Set the command used to invoke recipes and evaluate backticks
       on Windows.
 
@@ -2783,7 +2786,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    deprecated: None,
+    deprecated: Some("[windows] attribute on `set shell`"),
   },
   Builtin::Setting {
     name: "working-directory",

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -2786,7 +2786,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    deprecated: Some("[windows] attribute on `set shell`"),
+    deprecated: Some("`[windows]` attribute on `set shell`"),
   },
   Builtin::Setting {
     name: "working-directory",

--- a/src/deprecation.rs
+++ b/src/deprecation.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+#[derive(Clone, Copy, Debug)]
+pub enum Deprecation<'a> {
+  Replacement(&'a str),
+  SettingAttribute {
+    attribute: &'a str,
+    setting: &'a str,
+  },
+}
+
+impl Display for Deprecation<'_> {
+  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Replacement(replacement) => write!(f, "`{replacement}`"),
+      Self::SettingAttribute { attribute, setting } => {
+        write!(f, "`[{attribute}]` attribute on `set {setting}`")
+      }
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use {
   dependency::Dependency,
   dependency_argument::DependencyArgument,
   dependency_phase::DependencyPhase,
+  deprecation::Deprecation,
   diagnostic::Diagnostic,
   document::Document,
   error::Error,
@@ -70,6 +71,7 @@ mod count;
 mod dependency;
 mod dependency_argument;
 mod dependency_phase;
+mod deprecation;
 mod diagnostic;
 mod document;
 mod error;

--- a/src/quickfix.rs
+++ b/src/quickfix.rs
@@ -33,4 +33,30 @@ impl Quickfix {
       title: format!("Replace `{}` with `{replacement}`", name.value),
     }
   }
+
+  #[must_use]
+  pub fn setting_attribute(
+    setting: &Setting,
+    document: &Document,
+    attribute: &str,
+    replacement: &str,
+  ) -> Self {
+    let line = document
+      .content
+      .line(setting.range.start.line as usize)
+      .to_string();
+    let line = line.replacen(&setting.name.value, replacement, 1);
+
+    Self {
+      edits: vec![lsp::TextEdit {
+        range: setting.range,
+        new_text: format!("[{attribute}]\n{line}"),
+      }],
+      range: setting.name.range,
+      title: format!(
+        "Replace `{}` with `[{attribute}] set {replacement}`",
+        setting.name.value
+      ),
+    }
+  }
 }

--- a/src/quickfix.rs
+++ b/src/quickfix.rs
@@ -45,6 +45,7 @@ impl Quickfix {
       .content
       .line(setting.range.start.line as usize)
       .to_string();
+
     let line = line.replacen(&setting.name.value, replacement, 1);
 
     Self {

--- a/src/quickfixer.rs
+++ b/src/quickfixer.rs
@@ -227,6 +227,15 @@ mod tests {
   }
 
   #[test]
+  fn skips_non_rename_deprecated_setting() {
+    Test::new(
+      "set windows-shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]\n",
+    )
+    .range(lsp::Range::at(0, 4, 0, 4))
+    .run();
+  }
+
+  #[test]
   fn skips_disabled_rules() {
     let config = serde_json::from_value::<Config>(serde_json::json!({
       "rules": {

--- a/src/quickfixer.rs
+++ b/src/quickfixer.rs
@@ -246,6 +246,15 @@ mod tests {
   }
 
   #[test]
+  fn skips_windows_shell_setting_when_replacement_exists() {
+    Test::new(
+      "[windows]\nset shell := [\"foo\"]\nset windows-shell := [\"bar\"]\n",
+    )
+    .range(lsp::Range::at(2, 4, 2, 4))
+    .run();
+  }
+
+  #[test]
   fn skips_disabled_rules() {
     let config = serde_json::from_value::<Config>(serde_json::json!({
       "rules": {

--- a/src/quickfixer.rs
+++ b/src/quickfixer.rs
@@ -227,11 +227,21 @@ mod tests {
   }
 
   #[test]
-  fn skips_non_rename_deprecated_setting() {
+  fn replaces_windows_shell_setting() {
     Test::new(
       "set windows-shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]\n",
     )
     .range(lsp::Range::at(0, 4, 0, 4))
+    .quickfix(Quickfix {
+      edits: vec![lsp::TextEdit {
+        range: lsp::Range::at(0, 0, 1, 0),
+        new_text:
+          "[windows]\nset shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]\n"
+            .to_string(),
+      }],
+      range: lsp::Range::at(0, 4, 0, 17),
+      title: "Replace `windows-shell` with `[windows] set shell`".to_string(),
+    })
     .run();
   }
 

--- a/src/rule/deprecated_function.rs
+++ b/src/rule/deprecated_function.rs
@@ -12,13 +12,13 @@ define_rule! {
         let function_name = &function_call.name.value;
 
         if let Some(Builtin::Function {
-          deprecated: Some(replacement),
+          deprecated: Some(deprecation),
           ..
         }) = context.builtin_function(function_name.as_str())
         {
           diagnostics.push(Diagnostic::warning(
             format!(
-              "`{function_name}` is deprecated, use `{replacement}` instead"
+              "`{function_name}` is deprecated, use {deprecation} instead"
             ),
             function_call.name.range,
           ));
@@ -34,13 +34,13 @@ define_rule! {
         let function_name = &function_call.name.value;
 
         if let Some(Builtin::Function {
-          deprecated: Some(replacement),
+          deprecated: Some(Deprecation::Replacement(replacement)),
           ..
         }) = context.builtin_function(function_name.as_str())
         {
           quickfixes.push(Quickfix::replacement(
             &function_call.name,
-            replacement.to_string(),
+            *replacement,
           ));
         }
       }

--- a/src/rule/deprecated_setting.rs
+++ b/src/rule/deprecated_setting.rs
@@ -35,14 +35,17 @@ define_rule! {
           ..
         }) = context.builtin_setting(&setting.name.value)
         {
-          if replacement.chars().any(|c| c == ' ' || c == '`') {
-            continue;
-          }
+          let quickfix = match setting.name.value.as_str() {
+            "windows-shell" => Quickfix::setting_attribute(
+              setting,
+              context.document(),
+              "windows",
+              "shell",
+            ),
+            _ => Quickfix::replacement(&setting.name, replacement.to_string()),
+          };
 
-          quickfixes.push(Quickfix::replacement(
-            &setting.name,
-            replacement.to_string(),
-          ));
+          quickfixes.push(quickfix);
         }
       }
 

--- a/src/rule/deprecated_setting.rs
+++ b/src/rule/deprecated_setting.rs
@@ -10,19 +10,13 @@ define_rule! {
 
       for setting in context.settings() {
         if let Some(Builtin::Setting {
-          deprecated: Some(replacement),
+          deprecated: Some(deprecation),
           ..
         }) = context.builtin_setting(&setting.name.value)
         {
-          let replacement = if replacement.contains('`') {
-            replacement.to_string()
-          } else {
-            format!("`{replacement}`")
-          };
-
           diagnostics.push(Diagnostic::warning(
             format!(
-              "`{}` is deprecated, use {replacement} instead",
+              "`{}` is deprecated, use {deprecation} instead",
               setting.name.value
             ),
             setting.name.range,
@@ -34,21 +28,37 @@ define_rule! {
     },
     quickfixes(context) {
       let mut quickfixes = Vec::new();
-
       for setting in context.settings() {
         if let Some(Builtin::Setting {
-          deprecated: Some(replacement),
+          deprecated: Some(deprecation),
           ..
         }) = context.builtin_setting(&setting.name.value)
         {
-          let quickfix = match setting.name.value.as_str() {
-            "windows-shell" => Quickfix::setting_attribute(
-              setting,
-              context.document(),
-              "windows",
-              "shell",
-            ),
-            _ => Quickfix::replacement(&setting.name, replacement.to_string()),
+          let deprecation = *deprecation;
+
+          let quickfix = match deprecation {
+            Deprecation::Replacement(replacement) => {
+              Quickfix::replacement(&setting.name, replacement)
+            }
+            Deprecation::SettingAttribute {
+              attribute,
+              setting: replacement,
+            } => {
+              if context.settings().iter().any(|replacement_setting| {
+                replacement_setting.name.value == replacement
+                  && replacement_setting
+                    .has_attribute(context.attributes(), attribute)
+              }) {
+                continue;
+              }
+
+              Quickfix::setting_attribute(
+                setting,
+                context.document(),
+                attribute,
+                replacement,
+              )
+            }
           };
 
           quickfixes.push(quickfix);

--- a/src/rule/deprecated_setting.rs
+++ b/src/rule/deprecated_setting.rs
@@ -14,9 +14,15 @@ define_rule! {
           ..
         }) = context.builtin_setting(&setting.name.value)
         {
+          let replacement = if replacement.contains('`') {
+            replacement.to_string()
+          } else {
+            format!("`{replacement}`")
+          };
+
           diagnostics.push(Diagnostic::warning(
             format!(
-              "`{}` is deprecated, use `{replacement}` instead",
+              "`{}` is deprecated, use {replacement} instead",
               setting.name.value
             ),
             setting.name.range,

--- a/src/rule/deprecated_setting.rs
+++ b/src/rule/deprecated_setting.rs
@@ -46,8 +46,7 @@ define_rule! {
             } => {
               if context.settings().iter().any(|replacement_setting| {
                 replacement_setting.name.value == replacement
-                  && replacement_setting
-                    .has_attribute(context.attributes(), attribute)
+                  && replacement_setting.has_attribute(attribute)
               }) {
                 continue;
               }

--- a/src/rule/deprecated_setting.rs
+++ b/src/rule/deprecated_setting.rs
@@ -35,6 +35,10 @@ define_rule! {
           ..
         }) = context.builtin_setting(&setting.name.value)
         {
+          if replacement.chars().any(|c| c == ' ' || c == '`') {
+            continue;
+          }
+
           quickfixes.push(Quickfix::replacement(
             &setting.name,
             replacement.to_string(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -3210,47 +3210,6 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn code_action_windows_shell_deprecated() -> Result {
-    Test::new()
-      .request(InitializeRequest { id: 1 })
-      .response(InitializeResponse { id: 1 })
-      .notification(DidOpenNotification {
-        uri: "file:///test.just",
-        text: "set windows-shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]\n",
-      })
-      .request(CodeActionRequest {
-        id: 2,
-        uri: "file:///test.just",
-        range: lsp::Range::at(0, 4, 0, 4),
-      })
-      .response(json!({
-        "jsonrpc": "2.0",
-        "id": 2,
-        "result": [
-          {
-            "title": "Replace `windows-shell` with `[windows] set shell`",
-            "kind": "quickfix",
-            "edit": {
-              "changes": {
-                "file:///test.just": [
-                  {
-                    "range": {
-                      "start": { "line": 0, "character": 0 },
-                      "end": { "line": 1, "character": 0 }
-                    },
-                    "newText": "[windows]\nset shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]\n"
-                  }
-                ]
-              }
-            }
-          }
-        ]
-      }))
-      .run()
-      .await
-  }
-
-  #[tokio::test]
   async fn code_action_deprecated_function_outside_range() -> Result {
     Test::new()
       .request(InitializeRequest { id: 1 })

--- a/src/server.rs
+++ b/src/server.rs
@@ -3210,6 +3210,29 @@ mod tests {
   }
 
   #[tokio::test]
+  async fn code_action_windows_shell_deprecated_no_quickfix() -> Result {
+    Test::new()
+      .request(InitializeRequest { id: 1 })
+      .response(InitializeResponse { id: 1 })
+      .notification(DidOpenNotification {
+        uri: "file:///test.just",
+        text: "set windows-shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]\n",
+      })
+      .request(CodeActionRequest {
+        id: 2,
+        uri: "file:///test.just",
+        range: lsp::Range::at(0, 4, 0, 4),
+      })
+      .response(json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": []
+      }))
+      .run()
+      .await
+  }
+
+  #[tokio::test]
   async fn code_action_deprecated_function_outside_range() -> Result {
     Test::new()
       .request(InitializeRequest { id: 1 })

--- a/src/server.rs
+++ b/src/server.rs
@@ -3210,7 +3210,7 @@ mod tests {
   }
 
   #[tokio::test]
-  async fn code_action_windows_shell_deprecated_no_quickfix() -> Result {
+  async fn code_action_windows_shell_deprecated() -> Result {
     Test::new()
       .request(InitializeRequest { id: 1 })
       .response(InitializeResponse { id: 1 })
@@ -3226,7 +3226,25 @@ mod tests {
       .response(json!({
         "jsonrpc": "2.0",
         "id": 2,
-        "result": []
+        "result": [
+          {
+            "title": "Replace `windows-shell` with `[windows] set shell`",
+            "kind": "quickfix",
+            "edit": {
+              "changes": {
+                "file:///test.just": [
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 0 },
+                      "end": { "line": 1, "character": 0 }
+                    },
+                    "newText": "[windows]\nset shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]\n"
+                  }
+                ]
+              }
+            }
+          }
+        ]
       }))
       .run()
       .await

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -9,13 +9,6 @@ pub struct Setting {
 }
 
 impl Setting {
-  pub fn has_attribute(&self, name: &str) -> bool {
-    self
-      .attributes
-      .iter()
-      .any(|attribute| attribute.name.value == name)
-  }
-
   #[must_use]
   pub fn from_node(node: &Node, document: &Document) -> Option<Self> {
     let range = node.get_range(document);
@@ -100,6 +93,14 @@ impl Setting {
       name,
       range,
     })
+  }
+
+  #[must_use]
+  pub fn has_attribute(&self, name: &str) -> bool {
+    self
+      .attributes
+      .iter()
+      .any(|attribute| attribute.name.value == name)
   }
 }
 

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -9,6 +9,15 @@ pub struct Setting {
 }
 
 impl Setting {
+  pub fn has_attribute(&self, attributes: &[Attribute], name: &str) -> bool {
+    attributes.iter().any(|attribute| {
+      attribute.name.value == name
+        && attribute.target == Some(AttributeTarget::Setting)
+        && self.range.start <= attribute.range.start
+        && attribute.range.end <= self.range.end
+    })
+  }
+
   #[must_use]
   pub fn from_node(node: &Node, document: &Document) -> Option<Self> {
     let range = node.get_range(document);

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -9,13 +9,11 @@ pub struct Setting {
 }
 
 impl Setting {
-  pub fn has_attribute(&self, attributes: &[Attribute], name: &str) -> bool {
-    attributes.iter().any(|attribute| {
-      attribute.name.value == name
-        && attribute.target == Some(AttributeTarget::Setting)
-        && self.range.start <= attribute.range.start
-        && attribute.range.end <= self.range.end
-    })
+  pub fn has_attribute(&self, name: &str) -> bool {
+    self
+      .attributes
+      .iter()
+      .any(|attribute| attribute.name.value == name)
   }
 
   #[must_use]


### PR DESCRIPTION
Marks the `windows-shell` setting as deprecated (just master, casey/just#3536), surfacing deprecation diagnostics and completion metadata. The stock rename quickfix is skipped since the replacement is a pattern change (`[windows]` attribute on `set shell`), not a rename.