### PR TITLE
Add support for `min`, `max`, and `multiple` `[arg]` kwargs

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -396,8 +396,32 @@ mod tests {
       "
     })
     .error(
-      "Unknown `[arg]` keyword `bogus`, expected one of help, long, short, value, pattern, flag",
+      "Unknown `[arg]` keyword `bogus`, expected one of flag, help, long, max, min, multiple, pattern, short, value",
     lsp::Range::at(0, 13, 0, 22))
+    .run();
+  }
+
+  #[test]
+  fn arg_min_max_kwargs_accepted() {
+    Test::new(indoc! {
+      "
+      [arg('FILES', min='2', max='4')]
+      backup +FILES:
+        scp {{FILES}} me@server.com:
+      "
+    })
+    .run();
+  }
+
+  #[test]
+  fn arg_multiple_kwarg_accepted() {
+    Test::new(indoc! {
+      "
+      [arg('foo', long, multiple)]
+      bar foo:
+        echo {{foo}}
+      "
+    })
     .run();
   }
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -41,13 +41,26 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       - `pattern=\"PATTERN\"` requires the value to match a regular
         expression. Patterns are full-match; `just` rejects the
         invocation if the supplied value does not match.
+      - `multiple` allows an option or flag to be passed more than
+        once, assigning the list of passed values to the parameter.
+      - `min=MIN` requires at least `MIN` values. Requires `multiple`
+        or a variadic parameter.
+      - `max=MAX` allows at most `MAX` values. Requires `multiple` or
+        a variadic parameter.
 
       Multiple keys may be combined in a single `[arg(...)]`.
 
       ```just
+      set unstable
+      set lists
+
       [arg(NAME, long=\"name\", short=\"n\", help=\"greeting target\")]
       greet NAME:
         @echo Hello, {{NAME}}
+
+      [arg('FILES', min='2', max='4')]
+      backup +FILES:
+        scp {{FILES}} me@server.com:
       ```
       "
     },

--- a/src/rule/arg_attribute.rs
+++ b/src/rule/arg_attribute.rs
@@ -1,7 +1,8 @@
 use super::*;
 
-const VALID_KWARGS: &[&str] =
-  &["help", "long", "short", "value", "pattern", "flag"];
+const VALID_KWARGS: &[&str] = &[
+  "flag", "help", "long", "max", "min", "multiple", "pattern", "short", "value",
+];
 
 define_rule! {
   /// Validates `[arg(NAME, ...)]` attributes: that NAME refers to an existing


### PR DESCRIPTION
Recognizes the `min`, `max` (just master, casey/just#3524/#3522) and `multiple` kwargs on the `[arg(...)]` recipe attribute so valid justfiles no longer produce false-positive unknown-keyword diagnostics. Updates the `arg` attribute hover documentation accordingly.