### PR TITLE
Add support for `num_jobs` builtin function

### DIFF
--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -121,6 +121,7 @@ impl Builtin<'_> {
       }
       "arch"
       | "num_cpus"
+      | "num_jobs"
       | "os"
       | "os_family"
       | "is_dependency"

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1681,6 +1681,18 @@ pub const BUILTINS: &[Builtin<'_>] = &[
     deprecated: None,
   },
   Builtin::Function {
+    name: "num_jobs",
+    aliases: &[],
+    kind: FunctionKind::Nullary,
+    description: indoc! {
+      "
+      Return the value passed to `just` with `--jobs`, or an empty
+      list if `--jobs` was not passed.
+      "
+    },
+    deprecated: None,
+  },
+  Builtin::Function {
     name: "os",
     aliases: &[],
     kind: FunctionKind::Nullary,


### PR DESCRIPTION
Adds the `num_jobs()` builtin from current just master to the builtin catalog and completion metadata.

This prevents valid `num_jobs()` calls from being reported as unknown and provides the correct nullary completion snippet.

Checks: `cargo fmt --all`