### PR TITLE
Allow platform attributes on all items

### DIFF
--- a/src/attribute_target.rs
+++ b/src/attribute_target.rs
@@ -24,6 +24,9 @@ impl Display for AttributeTarget {
 }
 
 impl AttributeTarget {
+  pub const ALL: &[Self] =
+    &[Self::Alias, Self::Assignment, Self::Module, Self::Recipe];
+
   #[must_use]
   pub fn target_name(self) -> &'static str {
     match self {

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -20,7 +20,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    targets: &[AttributeTarget::Recipe],
+    targets: AttributeTarget::ALL,
   },
   Builtin::Attribute {
     name: "arg",
@@ -210,7 +210,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    targets: &[AttributeTarget::Recipe],
+    targets: AttributeTarget::ALL,
   },
   Builtin::Attribute {
     name: "env",
@@ -286,7 +286,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    targets: &[AttributeTarget::Recipe],
+    targets: AttributeTarget::ALL,
   },
   Builtin::Attribute {
     name: "group",
@@ -337,7 +337,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    targets: &[AttributeTarget::Recipe],
+    targets: AttributeTarget::ALL,
   },
   Builtin::Attribute {
     name: "macos",
@@ -359,7 +359,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    targets: &[AttributeTarget::Recipe],
+    targets: AttributeTarget::ALL,
   },
   Builtin::Attribute {
     name: "metadata",
@@ -393,7 +393,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       one of the active platforms matches.
       "
     },
-    targets: &[AttributeTarget::Recipe],
+    targets: AttributeTarget::ALL,
   },
   Builtin::Attribute {
     name: "no-cd",
@@ -474,7 +474,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       one of the active platforms matches.
       "
     },
-    targets: &[AttributeTarget::Recipe],
+    targets: AttributeTarget::ALL,
   },
   Builtin::Attribute {
     name: "parallel",
@@ -623,7 +623,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    targets: &[AttributeTarget::Recipe],
+    targets: AttributeTarget::ALL,
   },
   Builtin::Attribute {
     name: "windows",
@@ -643,7 +643,7 @@ pub const BUILTINS: &[Builtin<'_>] = &[
       ```
       "
     },
-    targets: &[AttributeTarget::Recipe],
+    targets: AttributeTarget::ALL,
   },
   Builtin::Attribute {
     name: "working-directory",


### PR DESCRIPTION
Allows platform-gating attributes such as `[linux]`, `[windows]`, and `[unix]` on aliases, assignments, modules, and recipes, matching current just master.

Previously, the language server reported false unsupported-target diagnostics when these attributes were used outside recipes.

Checks: `cargo fmt --all`; `cargo test attribute_target`