### PR TITLE
Allow const expressions in attributes

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -354,6 +354,21 @@ mod tests {
   }
 
   #[test]
+  fn arg_attribute_const_expression_kwargs() {
+    Test::new(indoc! {
+      "
+      help := 'help'
+      pattern := '[a-z]+'
+
+      [arg('bar', help=help, pattern=pattern)]
+      foo bar:
+        echo {{ bar }}
+      "
+    })
+    .run();
+  }
+
+  #[test]
   fn arg_attribute_empty_parens() {
     Test::new(indoc! {
       "
@@ -568,37 +583,6 @@ mod tests {
 
     case("long");
     case("short");
-  }
-
-  #[test]
-  fn arg_attribute_const_expression_kwargs() {
-    Test::new(indoc! {
-      "
-      help := 'help'
-      pattern := '[a-z]+'
-
-      [arg('bar', help=help, pattern=pattern)]
-      foo bar:
-        echo {{ bar }}
-      "
-    })
-    .run();
-  }
-
-  #[test]
-  fn doc_attribute_rejects_non_const_expression() {
-    Test::new(indoc! {
-      "
-      [doc(error('message'))]
-      foo:
-        echo foo
-      "
-    })
-    .error(
-      "Attribute `doc` arguments must be const expressions",
-      lsp::Range::at(0, 5, 0, 21),
-    )
-    .run();
   }
 
   #[test]
@@ -1458,6 +1442,22 @@ mod tests {
         echo {{ parent_dir('~/.config') }}
       "
     })
+    .run();
+  }
+
+  #[test]
+  fn doc_attribute_rejects_non_const_expression() {
+    Test::new(indoc! {
+      "
+      [doc(error('message'))]
+      foo:
+        echo foo
+      "
+    })
+    .error(
+      "Attribute `doc` arguments must be const expressions",
+      lsp::Range::at(0, 5, 0, 21),
+    )
     .run();
   }
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -566,10 +566,39 @@ mod tests {
         .run();
     }
 
-    case("help");
     case("long");
-    case("pattern");
     case("short");
+  }
+
+  #[test]
+  fn arg_attribute_const_expression_kwargs() {
+    Test::new(indoc! {
+      "
+      help := 'help'
+      pattern := '[a-z]+'
+
+      [arg('bar', help=help, pattern=pattern)]
+      foo bar:
+        echo {{ bar }}
+      "
+    })
+    .run();
+  }
+
+  #[test]
+  fn doc_attribute_rejects_non_const_expression() {
+    Test::new(indoc! {
+      "
+      [doc(error('message'))]
+      foo:
+        echo foo
+      "
+    })
+    .error(
+      "Attribute `doc` arguments must be const expressions",
+      lsp::Range::at(0, 5, 0, 21),
+    )
+    .run();
   }
 
   #[test]

--- a/src/rule/arg_attribute.rs
+++ b/src/rule/arg_attribute.rs
@@ -112,6 +112,11 @@ impl ArgAttributeRule {
     }
   }
 
+  fn const_expression(node: Node) -> bool {
+    node.find("function_call").is_none()
+      && node.find("external_command").is_none()
+  }
+
   fn validate(
     context: &RuleContext,
     attribute: Node,
@@ -181,9 +186,19 @@ impl ArgAttributeRule {
 
       let value = node.child_by_field_name("value")?;
 
-      (!Self::string_literal_expression(value)).then(|| {
+      let valid = if matches!(name.as_str(), "help" | "pattern") {
+        Self::const_expression(value)
+      } else {
+        Self::string_literal_expression(value)
+      };
+
+      (!valid).then(|| {
         Diagnostic::error(
-          "Attribute `arg` arguments must be string literals".to_string(),
+          if matches!(name.as_str(), "help" | "pattern") {
+            "Attribute `arg` arguments must be const expressions".to_string()
+          } else {
+            "Attribute `arg` arguments must be string literals".to_string()
+          },
           value.get_range(document),
         )
       })

--- a/src/rule/arg_attribute.rs
+++ b/src/rule/arg_attribute.rs
@@ -70,6 +70,11 @@ define_rule! {
 }
 
 impl ArgAttributeRule {
+  fn const_expression(node: Node) -> bool {
+    node.find("function_call").is_none()
+      && node.find("external_command").is_none()
+  }
+
   fn parameter_unknown(
     context: &RuleContext,
     attribute: Node,
@@ -93,11 +98,6 @@ impl ArgAttributeRule {
       .parameters
       .iter()
       .any(|parameter| parameter.name == parameter_name)
-  }
-
-  fn const_expression(node: Node) -> bool {
-    node.find("function_call").is_none()
-      && node.find("external_command").is_none()
   }
 
   fn string_literal_expression(node: Node) -> bool {

--- a/src/rule/arg_attribute.rs
+++ b/src/rule/arg_attribute.rs
@@ -95,6 +95,11 @@ impl ArgAttributeRule {
       .any(|parameter| parameter.name == parameter_name)
   }
 
+  fn const_expression(node: Node) -> bool {
+    node.find("function_call").is_none()
+      && node.find("external_command").is_none()
+  }
+
   fn string_literal_expression(node: Node) -> bool {
     let Some(value) = node.find("^value") else {
       return false;
@@ -110,11 +115,6 @@ impl ArgAttributeRule {
       }
       _ => false,
     }
-  }
-
-  fn const_expression(node: Node) -> bool {
-    node.find("function_call").is_none()
-      && node.find("external_command").is_none()
   }
 
   fn validate(

--- a/src/rule/attribute_argument_expressions.rs
+++ b/src/rule/attribute_argument_expressions.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 const EXPRESSION_ATTRIBUTES: &[&str] = &["confirm", "env", "working-directory"];
+const CONST_EXPRESSION_ATTRIBUTES: &[&str] = &["doc"];
 
 define_rule! {
   AttributeArgumentExpressionsRule {
@@ -45,6 +46,11 @@ impl AttributeArgumentExpressionsRule {
     }
   }
 
+  fn const_expression(node: Node) -> bool {
+    node.find("function_call").is_none()
+      && node.find("external_command").is_none()
+  }
+
   fn validate(context: &RuleContext, identifier: Node) -> Vec<Diagnostic> {
     let document = context.document();
 
@@ -54,6 +60,22 @@ impl AttributeArgumentExpressionsRule {
       [] => return Vec::new(),
       _ if EXPRESSION_ATTRIBUTES.contains(&attribute_name.as_str()) => {
         return Vec::new();
+      }
+      _ if CONST_EXPRESSION_ATTRIBUTES.contains(&attribute_name.as_str()) => {
+        return identifier
+          .siblings()
+          .take_while(|node| node.kind() != "identifier")
+          .filter(|node| node.kind() == "expression")
+          .filter(|node| !Self::const_expression(*node))
+          .map(|node| {
+            Diagnostic::error(
+              format!(
+                "Attribute `{attribute_name}` arguments must be const expressions"
+              ),
+              node.get_range(document),
+            )
+          })
+          .collect();
       }
       _ => {}
     }

--- a/src/rule/attribute_argument_expressions.rs
+++ b/src/rule/attribute_argument_expressions.rs
@@ -29,6 +29,11 @@ define_rule! {
 }
 
 impl AttributeArgumentExpressionsRule {
+  fn const_expression(node: Node) -> bool {
+    node.find("function_call").is_none()
+      && node.find("external_command").is_none()
+  }
+
   fn string_literal_expression(node: Node) -> bool {
     let Some(value) = node.find("^value") else {
       return false;
@@ -44,11 +49,6 @@ impl AttributeArgumentExpressionsRule {
       }
       _ => false,
     }
-  }
-
-  fn const_expression(node: Node) -> bool {
-    node.find("function_call").is_none()
-      && node.find("external_command").is_none()
   }
 
   fn validate(context: &RuleContext, identifier: Node) -> Vec<Diagnostic> {


### PR DESCRIPTION
Allows the const expressions documented by current just master in `[doc]` and `[arg(...)]` `help` and `pattern` arguments.

The language server previously reported false diagnostics because these arguments were restricted to string literals. Function calls and backtick commands remain rejected as non-const expressions.