### PR TITLE
Add support for `cache` attribute arguments

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -16,6 +16,8 @@ the rule’s identifier in the `code` field so editors can group or filter them.
 | `arg-attribute`                   | Arg Attribute                   | `[arg(NAME, ...)]` references an unknown parameter, duplicates a parameter config, or contains invalid keywords or keyword values. |
 | `attribute-invalid-target`        | Attribute Invalid Target        | Attribute is attached to a syntax element that cannot take attributes.                                                        |
 | `attribute-target-support`        | Attribute Target Support        | Attribute is used on an unsupported target kind.                                                                              |
+| `cache-attribute`                 | Cache Attribute                 | `[cache]` uses an unknown keyword, a keyword without a value, or a positional argument.                                      |
+| `cache-without-script`            | Cache Without Script            | Recipe uses `[cache]` without `[script]`.                                                                                     |
 | `duplicate-attribute`             | Duplicate Attribute             | Attributes that must be unique appear more than once on a target, or `[default]` appears more than once in a module.          |
 | `script-shebang-conflict`         | Script Shebang Conflict         | Recipe combines a shebang line with the `[script]` attribute.                                                                 |
 | `exit-message-conflict`           | Exit Message Conflict           | Recipe combines mutually exclusive `[exit-message]` and `[no-exit-message]` attributes.                                       |

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1837,6 +1837,73 @@ mod tests {
   }
 
   #[test]
+  fn cache_attribute_kwargs() {
+    Test::new(indoc! {
+      "
+      [script]
+      [cache(inputs='Cargo.lock', outputs='target', extra=arch())]
+      build:
+        cargo build
+      "
+    })
+    .run();
+  }
+
+  #[test]
+  fn cache_attribute_invalid_keyword_and_missing_value() {
+    Test::new(indoc! {
+      "
+      [script]
+      [cache(foo='bar', inputs)]
+      build:
+        cargo build
+      "
+    })
+    .error(
+      "Unknown `[cache]` keyword `foo`, expected one of extra, inputs, outputs",
+      lsp::Range::at(1, 7, 1, 16),
+    )
+    .error(
+      "`[cache]` keyword `inputs` requires a value",
+      lsp::Range::at(1, 18, 1, 24),
+    )
+    .run();
+  }
+
+  #[test]
+  fn cache_attribute_rejects_positional_arguments() {
+    Test::new(indoc! {
+      "
+      [script]
+      [cache('foo')]
+      build:
+        cargo build
+      "
+    })
+    .error(
+      "Attribute `cache` only accepts keyword arguments",
+      lsp::Range::at(1, 7, 1, 12),
+    )
+    .run();
+  }
+
+  #[test]
+  fn cache_without_script() {
+    Test::new(indoc! {
+      "
+      [cache]
+      build:
+        cargo build
+      "
+    })
+    .error(
+      "Recipe `build` uses `[cache]` without `[script]`",
+      lsp::Range::at(0, 0, 1, 0),
+    )
+    .run();
+  }
+
+  #[test]
   fn format_strings_mark_variables_as_used() {
     Test::new(indoc! {
       r#"

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1163,6 +1163,73 @@ mod tests {
   }
 
   #[test]
+  fn cache_attribute_invalid_keyword_and_missing_value() {
+    Test::new(indoc! {
+      "
+      [script]
+      [cache(foo='bar', inputs)]
+      build:
+        cargo build
+      "
+    })
+    .error(
+      "Unknown `[cache]` keyword `foo`, expected one of extra, inputs, outputs",
+      lsp::Range::at(1, 7, 1, 16),
+    )
+    .error(
+      "`[cache]` keyword `inputs` requires a value",
+      lsp::Range::at(1, 18, 1, 24),
+    )
+    .run();
+  }
+
+  #[test]
+  fn cache_attribute_kwargs() {
+    Test::new(indoc! {
+      "
+      [script]
+      [cache(inputs='Cargo.lock', outputs='target', extra=arch())]
+      build:
+        cargo build
+      "
+    })
+    .run();
+  }
+
+  #[test]
+  fn cache_attribute_rejects_positional_arguments() {
+    Test::new(indoc! {
+      "
+      [script]
+      [cache('foo')]
+      build:
+        cargo build
+      "
+    })
+    .error(
+      "Attribute `cache` only accepts keyword arguments",
+      lsp::Range::at(1, 7, 1, 12),
+    )
+    .run();
+  }
+
+  #[test]
+  fn cache_without_script() {
+    Test::new(indoc! {
+      "
+      [cache]
+      build:
+        cargo build
+      "
+    })
+    .error(
+      "Recipe `build` uses `[cache]` without `[script]`",
+      lsp::Range::at(0, 0, 1, 0),
+    )
+    .run();
+  }
+
+  #[test]
   fn circular_dependencies_long_chain() {
     Test::new(indoc! {
       "
@@ -1831,73 +1898,6 @@ mod tests {
     })
     .error(
       "Recipe `foo` uses `[extension]` without `[script]` or a shebang",
-      lsp::Range::at(0, 0, 1, 0),
-    )
-    .run();
-  }
-
-  #[test]
-  fn cache_attribute_kwargs() {
-    Test::new(indoc! {
-      "
-      [script]
-      [cache(inputs='Cargo.lock', outputs='target', extra=arch())]
-      build:
-        cargo build
-      "
-    })
-    .run();
-  }
-
-  #[test]
-  fn cache_attribute_invalid_keyword_and_missing_value() {
-    Test::new(indoc! {
-      "
-      [script]
-      [cache(foo='bar', inputs)]
-      build:
-        cargo build
-      "
-    })
-    .error(
-      "Unknown `[cache]` keyword `foo`, expected one of extra, inputs, outputs",
-      lsp::Range::at(1, 7, 1, 16),
-    )
-    .error(
-      "`[cache]` keyword `inputs` requires a value",
-      lsp::Range::at(1, 18, 1, 24),
-    )
-    .run();
-  }
-
-  #[test]
-  fn cache_attribute_rejects_positional_arguments() {
-    Test::new(indoc! {
-      "
-      [script]
-      [cache('foo')]
-      build:
-        cargo build
-      "
-    })
-    .error(
-      "Attribute `cache` only accepts keyword arguments",
-      lsp::Range::at(1, 7, 1, 12),
-    )
-    .run();
-  }
-
-  #[test]
-  fn cache_without_script() {
-    Test::new(indoc! {
-      "
-      [cache]
-      build:
-        cargo build
-      "
-    })
-    .error(
-      "Recipe `build` uses `[cache]` without `[script]`",
       lsp::Range::at(0, 0, 1, 0),
     )
     .run();

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -68,20 +68,21 @@ pub const BUILTINS: &[Builtin<'_>] = &[
   },
   Builtin::Attribute {
     name: "cache",
-    kind: AttributeKind::Nullary,
+    kind: AttributeKind::Variadic,
     description: indoc! {
       "
       Skip recipe invocations when a matching entry exists in the
       cache.
 
       Currently unstable. The `[cache]` attribute may only be used
-      with script recipes.
+      with script recipes. `inputs`, `outputs`, and `extra` keyword
+      arguments customize the cache key.
 
       ```just
       set unstable
 
       [script]
-      [cache]
+      [cache(inputs='Cargo.lock', outputs='target', extra=arch())]
       build:
         cargo build
       ```

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -49,6 +49,8 @@ mod attribute_argument_expressions;
 mod attribute_arguments;
 mod attribute_invalid_target;
 mod attribute_target_support;
+mod cache_attribute;
+mod cache_without_script;
 mod dependency_arguments;
 mod deprecated_function;
 mod deprecated_setting;

--- a/src/rule/attribute_argument_expressions.rs
+++ b/src/rule/attribute_argument_expressions.rs
@@ -1,6 +1,7 @@
 use super::*;
 
-const EXPRESSION_ATTRIBUTES: &[&str] = &["confirm", "env", "working-directory"];
+const EXPRESSION_ATTRIBUTES: &[&str] =
+  &["cache", "confirm", "env", "working-directory"];
 const CONST_EXPRESSION_ATTRIBUTES: &[&str] = &["doc"];
 
 define_rule! {

--- a/src/rule/cache_attribute.rs
+++ b/src/rule/cache_attribute.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+const VALID_KWARGS: &[&str] = &["extra", "inputs", "outputs"];
+
+define_rule! {
+  CacheAttributeRule {
+    id: "cache-attribute",
+    message: "invalid cache attribute",
+    run(context) {
+      let Some(tree) = context.tree() else {
+        return Vec::new();
+      };
+
+      let document = context.document();
+      let mut diagnostics = Vec::new();
+
+      for attribute in tree.root_node().find_all("attribute") {
+        for identifier in attribute.find_all("^identifier") {
+          if document.get_node_text(&identifier) != "cache" {
+            continue;
+          }
+
+          let arguments = identifier
+            .siblings()
+            .take_while(|node| node.kind() != "identifier")
+            .filter(|node| node.start_byte() != node.end_byte())
+            .collect::<Vec<_>>();
+
+          for argument in arguments.iter().filter(|node| node.kind() == "expression") {
+            diagnostics.push(Diagnostic::error(
+              "Attribute `cache` only accepts keyword arguments",
+              argument.get_range(document),
+            ));
+          }
+
+          for argument in arguments
+            .iter()
+            .filter(|node| node.kind() == "attribute_named_param")
+          {
+            let Some(name) = argument.child_by_field_name("name") else {
+              continue;
+            };
+
+            let name = document.get_node_text(&name);
+
+            if !VALID_KWARGS.contains(&name.as_str()) {
+              diagnostics.push(Diagnostic::error(
+                format!(
+                  "Unknown `[cache]` keyword `{name}`, expected one of {}",
+                  VALID_KWARGS.join(", ")
+                ),
+                argument.get_range(document),
+              ));
+            } else if argument.child_by_field_name("value").is_none() {
+              diagnostics.push(Diagnostic::error(
+                format!("`[cache]` keyword `{name}` requires a value"),
+                argument.get_range(document),
+              ));
+            }
+          }
+        }
+      }
+
+      diagnostics
+    }
+  }
+}

--- a/src/rule/cache_attribute.rs
+++ b/src/rule/cache_attribute.rs
@@ -12,6 +12,7 @@ define_rule! {
       };
 
       let document = context.document();
+
       let mut diagnostics = Vec::new();
 
       for attribute in tree.root_node().find_all("attribute") {

--- a/src/rule/cache_without_script.rs
+++ b/src/rule/cache_without_script.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+define_rule! {
+  CacheWithoutScriptRule {
+    id: "cache-without-script",
+    message: "cache without script",
+    run(context) {
+      let mut diagnostics = Vec::new();
+
+      for recipe in context.recipes() {
+        let Some(cache_attribute) = recipe.find_attribute("cache") else {
+          continue;
+        };
+
+        if recipe.has_attribute("script") {
+          continue;
+        }
+
+        diagnostics.push(Diagnostic::error(
+          format!(
+            "Recipe `{}` uses `[cache]` without `[script]`",
+            recipe.name.value
+          ),
+          cache_attribute.range,
+        ));
+      }
+
+      diagnostics
+    }
+  }
+}


### PR DESCRIPTION
Recognizes the `inputs`, `outputs`, and `extra` keyword arguments on the unstable `[cache]` recipe attribute so valid cached script recipes no longer produce false-positive diagnostics.

Adds diagnostics for invalid cache attribute arguments and for `[cache]` recipes missing `[script]`, and updates the cache hover documentation.