### PR TITLE
Add support for `len` and `style` builtin functions

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -2003,6 +2003,19 @@ mod tests {
   }
 
   #[test]
+  fn function_calls_len() {
+    Test::new(indoc! {
+      "
+      set lists
+
+      foo:
+        echo {{ len(['foo', 'bar']) }}
+      "
+    })
+    .run();
+  }
+
+  #[test]
   fn function_calls_split() {
     #[track_caller]
     fn case(expression: &str) {
@@ -2058,6 +2071,18 @@ mod tests {
       "Function `split` accepts at most 2 arguments, but 3 provided",
       lsp::Range::at(2, 7, 2, 35),
     )
+    .run();
+  }
+
+  #[test]
+  fn function_calls_style_accepts_optional_text() {
+    Test::new(indoc! {
+      "
+      foo:
+        echo {{ style('error') }}
+        echo {{ style('warning', 'careful') }}
+      "
+    })
     .run();
   }
 
@@ -2181,15 +2206,17 @@ mod tests {
       "
       bool(value) := value
       join_list(value) := value
+      len(value) := value
       show(value) := value
       split(value) := value
       which(value) := value
 
       foo := bool('foo')
       bar := join_list('bar')
-      baz := show('baz')
-      qux := split('qux')
-      quux := which('quux')
+      baz := len('baz')
+      qux := show('qux')
+      quux := split('quux')
+      corge := which('corge')
 
       recipe:
         echo {{ foo }}
@@ -2197,6 +2224,7 @@ mod tests {
         echo {{ baz }}
         echo {{ qux }}
         echo {{ quux }}
+        echo {{ corge }}
       "
     })
     .run();
@@ -2266,6 +2294,23 @@ mod tests {
     .error(
       "the `join_list()` function requires `set lists`",
       lsp::Range::at(0, 7, 0, 16),
+    )
+    .run();
+  }
+
+  #[test]
+  fn list_features_len_function_requires_lists() {
+    Test::new(indoc! {
+      "
+      foo := len('bar')
+
+      bar:
+        echo {{ foo }}
+      "
+    })
+    .error(
+      "the `len()` function requires `set lists`",
+      lsp::Range::at(0, 7, 0, 10),
     )
     .run();
   }

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -339,27 +339,4 @@ mod tests {
       ],
     );
   }
-
-  #[test]
-  fn function_completion_snippets() {
-    #[track_caller]
-    fn case(name: &str, expected: &str) {
-      let item = Builtin::Function {
-        name,
-        aliases: &[],
-        kind: FunctionKind::Nullary,
-        description: "",
-        deprecated: None,
-      }
-      .completion_items()
-      .into_iter()
-      .next()
-      .unwrap();
-
-      assert_eq!(item.insert_text.as_deref(), Some(expected));
-    }
-
-    case("len", "len(${1:value})");
-    case("style", "style(${1:styles:string}${2:, text:string})");
-  }
 }

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -115,7 +115,7 @@ impl Builtin<'_> {
       "assert" => {
         format!("{name}(${{1:condition}}${{2:, message:string}})")
       }
-      "bool" | "show" => format!("{name}(${{1:value}})"),
+      "bool" | "len" | "show" => format!("{name}(${{1:value}})"),
       "join_list" => {
         format!("{name}(${{1:value}}${{2:, separator:string}})")
       }
@@ -204,8 +204,11 @@ impl Builtin<'_> {
           "{name}(${{1:s:string}}, ${{2:regex:string}}, ${{3:replacement:string}})"
         )
       }
-      "require" | "style" | "which" => {
+      "require" | "which" => {
         format!("{name}(${{1:name:string}})")
+      }
+      "style" => {
+        format!("{name}(${{1:styles:string}}${{2:, text:string}})")
       }
       "semver_matches" => {
         format!("{name}(${{1:version:string}}, ${{2:requirement:string}})")
@@ -335,5 +338,28 @@ mod tests {
         },
       ],
     );
+  }
+
+  #[test]
+  fn function_completion_snippets() {
+    #[track_caller]
+    fn case(name: &str, expected: &str) {
+      let item = Builtin::Function {
+        name,
+        aliases: &[],
+        kind: FunctionKind::Nullary,
+        description: "",
+        deprecated: None,
+      }
+      .completion_items()
+      .into_iter()
+      .next()
+      .unwrap();
+
+      assert_eq!(item.insert_text.as_deref(), Some(expected));
+    }
+
+    case("len", "len(${1:value})");
+    case("style", "style(${1:styles:string}${2:, text:string})");
   }
 }

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1596,6 +1596,19 @@ pub const BUILTINS: &[Builtin<'_>] = &[
     deprecated: None,
   },
   Builtin::Function {
+    name: "len",
+    aliases: &[],
+    kind: FunctionKind::Unary,
+    description: indoc! {
+      "
+      Return the number of elements in `value`.
+
+      Requires `set lists`.
+      "
+    },
+    deprecated: None,
+  },
+  Builtin::Function {
     name: "lowercamelcase",
     aliases: &[],
     kind: FunctionKind::Unary,
@@ -2066,21 +2079,23 @@ pub const BUILTINS: &[Builtin<'_>] = &[
   Builtin::Function {
     name: "style",
     aliases: &[],
-    kind: FunctionKind::Unary,
+    kind: FunctionKind::UnaryOpt,
     description: indoc! {
       "
       Return the terminal display attribute escape sequence used by
-      `just` itself for styled output.
+      `just` itself for styled output. With `text`, return the styled
+      text followed by a reset sequence.
 
-      Unlike the plain color constants, `style(name)` produces the
-      exact sequence `just` uses, so recipe output can match
-      `just`'s own styling.
+      Unlike the plain color constants, `style(styles)` produces the
+      exact sequence `just` uses, so recipe output can match `just`'s
+      own styling.
 
-      Recognized values of `name`: `'command'` (echoed recipe lines),
-      `'error'`, and `'warning'`.
+      The `'command'`, `'error'`, and `'warning'` styles match `just`'s
+      echoed recipe lines and messages.
 
       ```just
       scary:
+        @echo '{{ style(\"warning\", \"careful!\") }}'
         @echo '{{ style(\"error\") }}OH NO{{ NORMAL }}'
       ```
       "

--- a/src/rule/list_features.rs
+++ b/src/rule/list_features.rs
@@ -67,6 +67,7 @@ impl ListFeaturesRule {
     match name {
       "bool" => Some("the `bool()` function requires `set lists`"),
       "join_list" => Some("the `join_list()` function requires `set lists`"),
+      "len" => Some("the `len()` function requires `set lists`"),
       "show" => Some("the `show()` function requires `set lists`"),
       "split" => Some("the `split()` function requires `set lists`"),
       "which" => Some("the `which()` function requires `set lists`"),


### PR DESCRIPTION
Adds the list-only `len(value)` builtin, including completion and list-feature diagnostics.

Updates `style` to accept its documented optional text argument and emits an appropriate completion snippet. The builtin hover documentation now describes both forms.

Validated with `cargo test --all --all-targets`, `cargo clippy --all --all-targets`, and `cargo fmt --all -- --check`.