### PR TITLE
Adjust unused variable rule to ignore variables starting with `_`

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -4056,6 +4056,20 @@ mod tests {
   }
 
   #[test]
+  fn underscore_suppresses_unused_variable_warnings() {
+    Test::new(indoc! {
+      "
+      _ := 'foo'
+      _bar := 'baz'
+
+      recipe:
+        echo 'Hello!'
+      "
+    })
+    .run();
+  }
+
+  #[test]
   fn settings_array_type_error() {
     Test::new(indoc! {
       "

--- a/src/rule/unused_variables.rs
+++ b/src/rule/unused_variables.rs
@@ -16,7 +16,7 @@ define_rule! {
       let exported = context.setting_enabled("export");
 
       for (variable_name, is_used) in &context.scope().variable_usage {
-        if *is_used {
+        if variable_name.starts_with('_') || *is_used {
           continue;
         }
 


### PR DESCRIPTION
I assume this should close #564 (should you agree to it of course).